### PR TITLE
Improvement/ui

### DIFF
--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -29,9 +29,12 @@
     }
   }
 }
+
 .primaryLink {
   color: $primary !important;
+  display: contents !important;
 }
+
 @media screen and (min-width: 320px) and (max-width: 767px) {
   .footerDefichainLink {
     margin-top: 1rem;

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -24,7 +24,7 @@ const FooterComponent = () => (
     <Row>
       <Col xs='12' md='4'>
         <Row>
-          <Col xs='12' className='mb-3'>
+          <Col xs='12'>
             <h5>
               {I18n.t('components.footerComponent.explorer.explorerTitle')}
             </h5>
@@ -73,7 +73,7 @@ const FooterComponent = () => (
       </Col>
       <Col xs='12' md='2' className={styles.footerDefichainLink}>
         <Row>
-          <Col xs='12' className='mb-3'>
+          <Col xs='12'>
             <h5>
               {I18n.t('components.footerComponent.deFiChain.deFiChainTitle')}
             </h5>
@@ -97,21 +97,21 @@ const FooterComponent = () => (
       </Col>
       <Col xs='12' md='6'>
         <Row>
-          <Col xs='12' className='mb-3'>
-            &nbsp;
-          </Col>
+          <Col xs='12'>&nbsp;</Col>
           <Col xs='12'>
             <p>{I18n.t('components.footerComponent.about.aboutContent')}</p>
             <p>
               {I18n.t('components.footerComponent.about.forMoreInfoNotice')}{' '}
-              <a
-                className={styles.primaryLink}
-                href={DEFICHAIN_IO_SITE}
-                rel='nofollow'
-                target='_blank'
-              >
-                {I18n.t('components.footerComponent.about.defiChainLink')}
-              </a>
+              <span>
+                <a
+                  className={styles.primaryLink}
+                  href={DEFICHAIN_IO_SITE}
+                  rel='nofollow'
+                  target='_blank'
+                >
+                  {I18n.t('components.footerComponent.about.defiChainLink')}
+                </a>
+              </span>
             </p>
           </Col>
         </Row>

--- a/src/components/KeyValueLi/index.tsx
+++ b/src/components/KeyValueLi/index.tsx
@@ -43,7 +43,8 @@ const KeyValueLi: React.FunctionComponent<KeyValueLiProps> = (
         </Button>
       );
     }
-    if (props.noEllipsis) return props.value;
+    if (props.noEllipsis)
+      return <div className='text-break'>{props.value}</div>;
 
     return <EllipsisText text={props.value} length={'50'} />;
   };

--- a/src/containers/PoolPairsListPage/components/PoolPairPage/index.tsx
+++ b/src/containers/PoolPairsListPage/components/PoolPairPage/index.tsx
@@ -59,13 +59,11 @@ const TokenPage = (props: TokenPageProps) => {
           <h1>
             <span>
               <TokenAvatar token={data.tokenInfo.idTokenA} />
-            </span>
+            </span>{' '}
             <span>
               <TokenAvatar token={data.tokenInfo.idTokenB} />
             </span>{' '}
-            {I18n.t('containers.poolPairPage.titlePair', {
-              symbol: data.symbol,
-            })}
+            {data.symbol}
           </h1>
           <Row>
             <Col xs='12' md='4'>

--- a/src/containers/PoolPairsListPage/components/PoolPairPage/index.tsx
+++ b/src/containers/PoolPairsListPage/components/PoolPairPage/index.tsx
@@ -131,6 +131,7 @@ const TokenPage = (props: TokenPageProps) => {
               <KeyValueLi
                 label={I18n.t('containers.poolPairPage.ownerAddress')}
                 value={`${data.ownerAddress}`}
+                noEllipsis
               />
             </Col>
           </Row>

--- a/src/containers/PoolPairsListPage/components/PoolPairsTable/index.tsx
+++ b/src/containers/PoolPairsListPage/components/PoolPairsTable/index.tsx
@@ -76,7 +76,7 @@ const PoolPairsTable = (props: PoolPairsTable) => {
           <td>
             <span>
               <TokenAvatar token={item.tokenInfo.idTokenA} />
-            </span>
+            </span>{' '}
             <span>
               <TokenAvatar token={item.tokenInfo.idTokenB} />
             </span>{' '}

--- a/src/containers/TokensListPage/components/TokenPage/index.tsx
+++ b/src/containers/TokensListPage/components/TokenPage/index.tsx
@@ -65,38 +65,6 @@ const TokenPage = (props: TokenPageProps) => {
           </h1>
           <Row>
             <Col xs='12'>
-              {/* <Row>
-                <Col xs='12' md='4'>
-                  <KeyValueLi
-                    label={I18n.t('containers.tokenPage.name')}
-                    value={data.name || 'Unknown'}
-                  />
-                </Col>
-                <Col xs='12' md='4'>
-                  <KeyValueLi
-                    label={I18n.t('containers.tokenPage.symbol')}
-                    value={data.symbol || 'Unknown'}
-                  />
-                </Col>
-                <Col xs='12' md='4'>
-                  <KeyValueLi
-                    label={I18n.t('containers.tokenPage.tokenId')}
-                    value={data.tokenId}
-                  />
-                </Col>
-                <Col xs='12' md='4'>
-                  <KeyValueLi
-                    label={I18n.t('containers.tokenPage.category')}
-                    value={data.category}
-                  />
-                </Col>
-                <Col xs='12' md='4'>
-                  <KeyValueLi
-                    label={I18n.t('containers.tokenPage.decimal')}
-                    value={`${data.decimal}`}
-                  />
-                </Col>
-              </Row> */}
               <Row>
                 <Col xs='12' md='4'>
                   <KeyValueLi

--- a/src/containers/TokensListPage/index.tsx
+++ b/src/containers/TokensListPage/index.tsx
@@ -71,7 +71,9 @@ const TokensListPage = (props: TokensListPageProps) => {
             <div>{item.category}</div>
           </td>
           <td>
-            <div>{item.mintable ? `${item.minted} ${item.symbol}` : '-'}</div>
+            <div>
+              {item.mintable ? `${parseFloat(item.minted).toFixed(2)}` : '-'}
+            </div>
           </td>
           <td>
             <div>{capitalize(item.tradeable)}</div>

--- a/src/translations/languages/en.json
+++ b/src/translations/languages/en.json
@@ -39,7 +39,7 @@
       "about": {
         "aboutContent": "DeFi Blockchain’s primary vision is to enable decentralized finance with Bitcoin-grade security, strength and immutability. It's a blockchain dedicated to fast, intelligent and transparent financial services, accessible by everyone.",
         "forMoreInfoNotice": "For more information, please visit our website at",
-        "defiChainLink": "deFichain.io"
+        "defiChainLink": "defichain.com"
       }
     }
   },
@@ -211,7 +211,6 @@
       "loading": "Loading"
     },
     "poolPairPage": {
-      "titlePair": "%{symbol} pair",
       "poolPairListPageBreadCrumb": "Pool",
       "oneCurrencyLabel": "1 %{symbol}",
       "poolPairId": "Id",


### PR DESCRIPTION

**Body – Tokens tab**
• Suggest to remove symbol from Minted column
• Reduce numbers to 2 decimal place, for better consistency & readability

**Body – Pool tab**
• Insert gap between icons

**Footer** 
• Shift links up so that baseline of first links <Token> and <DeFiChain.io>
• Decrease gap to suggested gap height (orange box) 
• Check when window is narrowed (responsive window), gap height should be reflected too (orange box)
• Rename “deFichain.io” to “defichain.com”
• Move <deFichain.io> link to start after “… please visit our website at <insert link> ” 

**Body – Token > BTC**
• Check when window is narrowed (responsive window), 
unable to see [Creation Tx] & [Destruction Tx]

**Body – Pool > DFI-BTC**
• Increase gap between icons
• Remove “pair” word, “DFI-BTC” is sufficient
• Check when window is narrowed (responsive window), 
unable to see Owner Address
